### PR TITLE
Added attribute to Photocathode to allow eta_t to be set manually. 

### DIFF
--- a/lib/Physics/UEMColumn/Auxiliary.pm
+++ b/lib/Physics/UEMColumn/Auxiliary.pm
@@ -26,7 +26,7 @@ use Math::Trig;
 use parent 'Exporter';
 our %EXPORT_TAGS = ( 
   constants   => [ qw/ pi me qe epsilon_0 vc / ],
-  model_funcs => [ qw/ L L_t L_z dLdxi dL_tdxi dL_zdxi / ],
+  model_funcs => [ qw/ L L_t L_z dLdxi dL_tdxi dL_zdxi lorentz_gamma u_z/ ],
   util_funcs  => [ qw/ join_data / ],
   materials   => [ qw/ Ta / ],
 );
@@ -119,15 +119,23 @@ sub L {
 sub L_t {
   my ($xi) = @_;
   my $L = L($xi);
-
   return 1.5 * ( $L + (($xi**2)*$L - $xi) / (1 - $xi**2) );
 }
 
 sub L_z {
   my ($xi) = @_;
   my $L = L($xi);
-
   return 3 * ($xi**2) * ( $xi * $L - 1) / (($xi**2) - 1)
+}
+
+sub lorentz_gamma {
+  my ($v) = @_;
+  return 1 / sqrt(1 - ($v/vc)**2 )
+}
+
+sub u_z {
+  my ($sz,$gz) = @_;
+  return $gz / me / sqrt($sz)
 }
 
 sub dL_tdxi {

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -31,6 +31,7 @@ use Physics::UEMColumn::Pulse;
 use Physics::UEMColumn::Auxiliary qw/:constants/;
 
 my $type_energy = num_of_unit( 'J' );
+my $type_eta    = num_of_unit('(kg J)');
 
 =head1 ATTRIBUTES
 
@@ -38,11 +39,19 @@ my $type_energy = num_of_unit( 'J' );
 
 =item C<work_function>
 
-The "work function" of the material. Rquired. Unit: J
+The "work function" of the material. Required. Unit: J
 
 =cut
 
 has 'work_function' => ( isa => $type_energy, is => 'ro', required => 1 );
+
+=item C<eta_t>
+
+The RMS transverse momentum spread (squared) of a photoexcited pulse from the Photocathode. It can either be set manually (e.g., fitting of experimental data) or by default. WARNING! The default is determined by the expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
+
+=cut
+
+has 'eta_t' => ( isa => $type_eta, is => 'ro', default => 0 );
 
 =item C<location>
 
@@ -99,7 +108,7 @@ method generate_pulse ( Num $num ) {
   my $delta_E = $e_laser - $work_function;
   my $velfront = sqrt( 2 * $delta_E / me );
 
-  my $eta_t = me / 3 * ( $e_laser - $work_function );
+  my $eta_t = $self->eta_t || me / 3 * ( $e_laser - $work_function );
   my $sigma_z = (($velfront*$tau)**2) / 2 + ( qe / ( 4 * me ) * $field * ($tau**2))**2;
 
   my $pulse = Physics::UEMColumn::Pulse->new(

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -31,7 +31,6 @@ use Physics::UEMColumn::Pulse;
 use Physics::UEMColumn::Auxiliary qw/:constants/;
 
 my $type_energy = num_of_unit( 'J' );
-my $type_eta    = num_of_unit('(kg J)');
 
 =head1 ATTRIBUTES
 
@@ -39,19 +38,11 @@ my $type_eta    = num_of_unit('(kg J)');
 
 =item C<work_function>
 
-The "work function" of the material. Required. Unit: J
+The "work function" of the material. Rquired. Unit: J
 
 =cut
 
 has 'work_function' => ( isa => $type_energy, is => 'ro', required => 1 );
-
-=item C<eta_t>
-
-The RMS transverse momentum spread (squared) of a photoexcited pulse from the Photocathode. It can either be set manually (e.g., fitting of experimental data) or by default. WARNING! The default is determined by the expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
-
-=cut
-
-has 'eta_t' => ( isa => $type_eta, is => 'ro', default => 0 );
 
 =item C<location>
 
@@ -108,7 +99,7 @@ method generate_pulse ( Num $num ) {
   my $delta_E = $e_laser - $work_function;
   my $velfront = sqrt( 2 * $delta_E / me );
 
-  my $eta_t = $self->eta_t || me / 3 * ( $e_laser - $work_function );
+  my $eta_t = me / 3 * ( $e_laser - $work_function );
   my $sigma_z = (($velfront*$tau)**2) / 2 + ( qe / ( 4 * me ) * $field * ($tau**2))**2;
 
   my $pulse = Physics::UEMColumn::Pulse->new(


### PR DESCRIPTION
I added the unit type for Delta p_T^2 (mass*energy).
Since the default is determined by the laser energy (Dowell's expression) it gets set when generate_pulse is called. Thus, the default for eta_t is 0 which triggers a False on the OR statement later on. This seemed easiest, but perhaps not the best method.

Thought I'd send some of my edits your way...
