### PR TITLE
Allow for Delta p_T to be set manually

### DIFF
--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -31,7 +31,6 @@ use Physics::UEMColumn::Pulse;
 use Physics::UEMColumn::Auxiliary qw/:constants/;
 
 my $type_energy = num_of_unit( 'J' );
-my $type_eta    = num_of_unit('kg J');
 
 =head1 ATTRIBUTES
 
@@ -51,7 +50,7 @@ The RMS transverse momentum spread (squared) of a photoexcited pulse from the Ph
 
 =cut
 
-has 'eta_t' => ( isa => $type_eta, is => 'ro', lazy => 1, builder => '_set_eta_t' );
+has 'eta_t' => ( isa => num_of_unit('kg J'), is => 'ro', lazy => 1, builder => '_set_eta_t' );
 
 =item C<effective_mass>
 
@@ -141,6 +140,7 @@ A method that builds eta_t. Currently sets eta_t based on an expression derived 
 =cut
 
 method _set_eta_t {
+  die 'Photocathode requires access to column object' unless $self->has_column;
   my $column = $self->column;
   my $laser = $column->laser;
 

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -31,6 +31,7 @@ use Physics::UEMColumn::Pulse;
 use Physics::UEMColumn::Auxiliary qw/:constants/;
 
 my $type_energy = num_of_unit( 'J' );
+my $type_eta    = num_of_unit('(kg J)');
 
 =head1 ATTRIBUTES
 
@@ -38,11 +39,19 @@ my $type_energy = num_of_unit( 'J' );
 
 =item C<work_function>
 
-The "work function" of the material. Rquired. Unit: J
+The "work function" of the material. Required. Unit: J
 
 =cut
 
 has 'work_function' => ( isa => $type_energy, is => 'ro', required => 1 );
+
+=item C<eta_t>
+
+The RMS transverse momentum spread (squared) of a photoexcited pulse from the Photocathode. It can either be set manually (e.g., fitting of experimental data) or by default. WARNING! The default is determined by the expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
+
+=cut
+
+has 'eta_t' => ( isa => $type_eta, is => 'ro', default => 0 );
 
 =item C<location>
 
@@ -99,7 +108,7 @@ method generate_pulse ( Num $num ) {
   my $delta_E = $e_laser - $work_function;
   my $velfront = sqrt( 2 * $delta_E / me );
 
-  my $eta_t = me / 3 * ( $e_laser - $work_function );
+  my $eta_t = $self->eta_t || me / 3 * ( $e_laser - $work_function );
   my $sigma_z = (($velfront*$tau)**2) / 2 + ( qe / ( 4 * me ) * $field * ($tau**2))**2;
 
   my $pulse = Physics::UEMColumn::Pulse->new(

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -31,7 +31,7 @@ use Physics::UEMColumn::Pulse;
 use Physics::UEMColumn::Auxiliary qw/:constants/;
 
 my $type_energy = num_of_unit( 'J' );
-my $type_eta    = num_of_unit('(kg J)');
+my $type_eta    = num_of_unit('kg J');
 
 =head1 ATTRIBUTES
 
@@ -59,7 +59,7 @@ The effective mass of the electron inside the metal associated with the band the
 
 =cut
 
-has 'effective_mass' => (isa => num_of_unit('(kg)'), is => 'ro', default => me);
+has 'effective_mass' => (isa => num_of_unit('kg'), is => 'ro', default => me);
 
 =item C<location>
 

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -47,11 +47,11 @@ has 'work_function' => ( isa => $type_energy, is => 'ro', required => 1 );
 
 =item C<eta_t>
 
-The RMS transverse momentum spread (squared) of a photoexcited pulse from the Photocathode. It can either be set manually (e.g., fitting of experimental data) or by default. WARNING! The default is determined by the expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
+The RMS transverse momentum spread (squared) of a photoexcited pulse from the Photocathode. It can either be set manually (e.g., for fitting of experimental data) or by default.
 
 =cut
 
-has 'eta_t' => ( isa => $type_eta, is => 'ro', default => 0 );
+has 'eta_t' => ( isa => $type_eta, is => 'ro', lazy => 1, builder => '_set_eta_t' );
 
 =item C<location>
 
@@ -108,7 +108,7 @@ method generate_pulse ( Num $num ) {
   my $delta_E = $e_laser - $work_function;
   my $velfront = sqrt( 2 * $delta_E / me );
 
-  my $eta_t = $self->eta_t || me / 3 * ( $e_laser - $work_function );
+  my $eta_t = $self->eta_t;
   my $sigma_z = (($velfront*$tau)**2) / 2 + ( qe / ( 4 * me ) * $field * ($tau**2))**2;
 
   my $pulse = Physics::UEMColumn::Pulse->new(
@@ -124,6 +124,22 @@ method generate_pulse ( Num $num ) {
   );
 
   return $pulse;
+}
+
+=item C<_set_eta_t>
+
+A method that builds eta_t. Currently sets eta_t based on an expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
+
+=cut
+
+method _set_eta_t {
+  my $column = $self->column;
+  my $laser = $column->laser;
+
+  my $e_laser = $laser->energy;
+  my $work_function = $self->work_function;
+
+  return me / 3 * ( $e_laser - $work_function )
 }
 
 =back

--- a/lib/Physics/UEMColumn/Photocathode.pm
+++ b/lib/Physics/UEMColumn/Photocathode.pm
@@ -53,6 +53,14 @@ The RMS transverse momentum spread (squared) of a photoexcited pulse from the Ph
 
 has 'eta_t' => ( isa => $type_eta, is => 'ro', lazy => 1, builder => '_set_eta_t' );
 
+=item C<effective_mass>
+
+The effective mass of the electron inside the metal associated with the band the electron is emitted from.
+
+=cut
+
+has 'effective_mass' => (isa => num_of_unit('(kg)'), is => 'ro', default => me);
+
 =item C<location>
 
 The location of the Photocathode in the Column. This value will be used as the location of the generated Pulse object. The default is C<0>.
@@ -128,7 +136,7 @@ method generate_pulse ( Num $num ) {
 
 =item C<_set_eta_t>
 
-A method that builds eta_t. Currently sets eta_t based on an expression derived by Dowell [See doi:10.1103/PhysRevSTAB.12.074201] which has been shown to be inconsistent with experimental data.
+A method that builds eta_t. Currently sets eta_t based on an expression derived in [http://dx.doi.org/10.1103/PhysRevLett.111.237401] which has been shown to be consistent with experimental data.
 
 =cut
 
@@ -138,8 +146,9 @@ method _set_eta_t {
 
   my $e_laser = $laser->energy;
   my $work_function = $self->work_function;
+  my $me = $self->effective_mass;
 
-  return me / 3 * ( $e_laser - $work_function )
+  return $me / 3 * ( $e_laser - $work_function )
 }
 
 =back


### PR DESCRIPTION
I added the unit type for Delta p_T^2 (mass*energy).
Since the default is determined by the laser energy (Dowell's expression) it gets set when generate_pulse is called. Thus, the default for eta_t is 0 which triggers a False on the OR statement later on. This seemed easiest, but perhaps not the best method.
